### PR TITLE
Fix Results Indendation

### DIFF
--- a/MFASweep.ps1
+++ b/MFASweep.ps1
@@ -220,7 +220,7 @@ Function Invoke-MFASweep{
     else{Write-Host "O365 w/ Windows Phone UA $Tab$Tab| $global:o365wpresult"}
     if($global:ewsresult -contains "YES"){Write-Host -NoNewLine "Exchange Web Services $Tab$Tab$Tab|"; Write-Host -ForegroundColor Green " $global:ewsresult"}
     else{Write-Host "Exchange Web Services $Tab$Tab$Tab| $global:ewsresult"}
-    if($global:asyncresult -contains "YES"){Write-Host -NoNewLine "Active Sync $Tab$Tab$Tab|"; Write-Host -ForegroundColor Green " $global:asyncresult"}
+    if($global:asyncresult -contains "YES"){Write-Host -NoNewLine "Active Sync $Tab$Tab$Tab$Tab|"; Write-Host -ForegroundColor Green " $global:asyncresult"}
     else{Write-Host "Active Sync $Tab$Tab$Tab$Tab| $global:asyncresult"}
     
     If($IncludeADFS){

--- a/MFASweep.ps1
+++ b/MFASweep.ps1
@@ -224,8 +224,8 @@ Function Invoke-MFASweep{
     else{Write-Host "Active Sync $Tab$Tab$Tab$Tab| $global:asyncresult"}
     
     If($IncludeADFS){
-    if($glotbal:adfsresult -contains "YES"){Write-Host -NoNewLine "ADFS $Tab$Tab$Tab|"; Write-Host -ForegroundColor Green " $global:adfsresult"}
-    else{Write-Host "ADFS $Tab$Tab| $global:adfsresult"}
+    if($glotbal:adfsresult -contains "YES"){Write-Host -NoNewLine "ADFS $Tab$Tab$Tab$Tab$Tab|"; Write-Host -ForegroundColor Green " $global:adfsresult"}
+    else{Write-Host "ADFS $Tab$Tab$Tab$Tab$Tab| $global:adfsresult"}
     }
 }
 


### PR DESCRIPTION
In the current version of MFASweep, there are two tab issues that resulted in the indentation of the table being off:

1. If ActiveSync was enabled, only three tabs were used. This resulted in the "Yes" being one tab to the left of the other results.
2. The tabs for ADFS were off, both for enabled and disabled. 

Both of these tab issues have been corrected.