### PR TITLE
Add support for Linux filesystem paths when writing tokens & cookies to disk

### DIFF
--- a/MFASweep.ps1
+++ b/MFASweep.ps1
@@ -1077,7 +1077,7 @@ Function Write-TokensToFile {
     )
 
     if ($WriteTokens) {
-        $tokenFilePath = "$PSScriptRoot\AccessTokens.json"
+        $tokenFilePath = Join-Path ("$PSScriptRoot" ? "$PSScriptRoot" : ".") "AccessTokens.json"
         $currentDate = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
 
         # Create the new token entry
@@ -1115,7 +1115,7 @@ Function Write-CookiesToFile {
         [string]$UserAgent
     )
 
-    $tokenFilePath = "$PSScriptRoot\AccessTokens.json"
+    $tokenFilePath = Join-Path ("$PSScriptRoot" ? "$PSScriptRoot" : ".") "AccessTokens.json"
     $currentDate = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
 
     # Prepare cookie data


### PR DESCRIPTION
Simple fix that updates the Write-CookiesToFile and Write-TokensToFile functions to use `Join-Path` instead of a static path with the `\` character.